### PR TITLE
feature: capture enclosing environment

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,11 +2,9 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
-        - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true

--- a/src/BladeCaptureDirective.php
+++ b/src/BladeCaptureDirective.php
@@ -14,7 +14,7 @@ final class BladeCaptureDirective
 
         return "
             <?php {$name} = (function ({$args}) {
-                extract(\$this->environment);
+                extract(array_merge(\$this->environment, get_defined_vars()));
                 ob_start();
             ?>
         ";

--- a/src/BladeCaptureDirective.php
+++ b/src/BladeCaptureDirective.php
@@ -13,7 +13,8 @@ final class BladeCaptureDirective
             [$expression, ''];
 
         return "
-            <?php {$name} = function ({$args}) {
+            <?php {$name} = (function ({$args}) {
+                extract(\$this->environment);
                 ob_start();
             ?>
         ";
@@ -22,7 +23,13 @@ final class BladeCaptureDirective
     public static function close()
     {
         return "
-            <?php return new \Illuminate\Support\HtmlString(ob_get_clean()); }; ?>
+            <?php
+                return new \Illuminate\Support\HtmlString(ob_get_clean());
+            })->bindTo(new class(get_defined_vars()) {
+                public function __construct(
+                    public array \$environment = []
+                ) {}
+            }); ?>
         ";
     }
 }

--- a/tests/CaptureDirectiveTest.php
+++ b/tests/CaptureDirectiveTest.php
@@ -84,3 +84,16 @@ it('captures the external environment', function () {
     blade)
         ->toContain('Hello, Ryan!');
 });
+
+it('captures the external environment and capture block arguments take precedence', function () {
+    expectBlade(<<<blade
+        @php(\$name = 'Ryan')
+
+        @capture(\$hello, \$name)
+            Hello, {{ \$name }}!
+        @endcapture
+
+        {{ \$hello('John') }}
+    blade)
+        ->toContain('Hello, John!');
+});


### PR DESCRIPTION
This makes captured blocks act more like partials. They now automatically capture their enclosing environment.

```blade
@php($user = user())

@capture($hello)
	Hello, {{ $user->name }}!
@endcapture

{{ $hello }}
```

This example will now work. The `$user` variable declared on line 1 of the file will be available in the capture block.

> **Trigger warning** - this is some magical code and I absolutely love it.