### PR TITLE
fix: maintain `$this` binding of captured closure

### DIFF
--- a/src/BladeCaptureDirective.php
+++ b/src/BladeCaptureDirective.php
@@ -13,23 +13,18 @@ final class BladeCaptureDirective
             [$expression, ''];
 
         return "
-            <?php {$name} = (function ({$args}) {
-                extract(array_merge(\$this->environment, get_defined_vars()));
-                ob_start();
-            ?>
+            <?php {$name} = (function (\$args) {
+                return function ({$args}) use (\$args) {
+                    extract(\$args, EXTR_SKIP);
+                    ob_start(); ?>
         ";
     }
 
     public static function close()
     {
         return "
-            <?php
-                return new \Illuminate\Support\HtmlString(ob_get_clean());
-            })->bindTo(new class(get_defined_vars()) {
-                public function __construct(
-                    public array \$environment = []
-                ) {}
-            }); ?>
+            <?php return new \Illuminate\Support\HtmlString(ob_get_clean()); };
+                })(get_defined_vars()); ?>
         ";
     }
 }


### PR DESCRIPTION
When Livewire components are rendered, they're implicitly bound to the Livewire component object via `$this`. The old implementation of this package was using a custom binding to handle captured environments.

The new approach will instead maintain any existing `$this` bindings and instead use a currying/partial function application approach to capture environments instead.